### PR TITLE
Typesafe for `register`, `setFieldValue`, `setFieldError`,  and `setFieldTouched`

### DIFF
--- a/docs/components/NativeDemo.tsx
+++ b/docs/components/NativeDemo.tsx
@@ -3,13 +3,25 @@ import { createForm } from "@createform/react";
 const useForm = createForm({
   initialValues: {
     email: "",
+    test: [1, 2, 3, 4, 5, 6, 7, 8, 9],
   },
   mode: "onChange",
 });
 
 export function FormDemo() {
-  const { register, handleSubmit, state, handleReset } = useForm();
+  const {
+    register,
+    setFieldError,
+    handleSubmit,
+    state,
+    handleReset,
+    setFieldValue,
+  } = useForm();
   const { errors, touched } = state;
+
+  setFieldValue("email", 23);
+
+  setFieldError("test", "23");
 
   return (
     <form
@@ -30,11 +42,18 @@ export function FormDemo() {
         <input
           id="email"
           className="shadow-sm bg-transparent border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-transparent dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500 dark:shadow-sm-light"
+          {...register("test.5")}
+        />
+        <input
+          id="email"
+          className="shadow-sm bg-transparent border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-transparent dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500 dark:shadow-sm-light"
+          {...register({ name: "test.0" })}
+        />
+        <input
           {...register({
-            name: "email",
+            name: "email", // (property) name: "email" | "test" | `test.${number}`
             type: "email",
             placeholder: "createform@demo.com",
-            required: true,
           })}
         />
         <span className="text-red-600">{touched.email && errors.email}</span>

--- a/docs/components/NativeDemo.tsx
+++ b/docs/components/NativeDemo.tsx
@@ -4,6 +4,10 @@ const useForm = createForm({
   initialValues: {
     email: "",
     test: [1, 2, 3, 4, 5, 6, 7, 8, 9],
+    address: {
+      street: "",
+      number: null,
+    },
   },
   mode: "onChange",
 });
@@ -21,7 +25,8 @@ export function FormDemo() {
 
   setFieldValue("email", 23);
 
-  setFieldError("test", "23");
+  setFieldError("test.4", "Error message");
+  setFieldValue("address.number", 23);
 
   return (
     <form

--- a/packages/react/src/CreateForm.ts
+++ b/packages/react/src/CreateForm.ts
@@ -177,7 +177,7 @@ export function createForm<T extends CreateFormArgs<T["initialValues"]>>(
      *   />
      * );
      */
-    function register(args: RegisterArgs) {
+    function register(args: RegisterArgs<T["initialValues"]>) {
       let props = {} as any;
 
       if (typeof args === "object") {
@@ -199,14 +199,14 @@ export function createForm<T extends CreateFormArgs<T["initialValues"]>>(
       }, [ref]);
 
       React.useEffect(() => {
-        if (ref.current && args.validate) {
+        if (ref.current && props.validate) {
           handleInlineValidation(defaultValue);
         }
       }, [ref]);
 
       async function handleInlineValidation(value: any) {
         try {
-          await validate(value, args.validate);
+          await validate(value, props.validate);
           $store.patch(`errors.${props.name}`, undefined);
         } catch (error: any) {
           $store.patch(`errors.${props.name}`, error.message);
@@ -215,7 +215,7 @@ export function createForm<T extends CreateFormArgs<T["initialValues"]>>(
 
       function onBlur(e: EventChange) {
         handleBlur(e);
-        if (args.validate) {
+        if (props.validate) {
           handleInlineValidation(e.target.value);
         }
       }

--- a/packages/react/src/Types.ts
+++ b/packages/react/src/Types.ts
@@ -107,14 +107,15 @@ export type StateChange<T> = T | ((state: T) => T);
 
 export type StateOfField = "values" | "touched" | "errors";
 
-export type RegisterArgs = (React.InputHTMLAttributes<Field> | string) & {
+export type RegisterArgs<T> = React.InputHTMLAttributes<Field> & {
   validate?: any;
+  name: Paths<T>;
 };
 
 export type Form<T> = (hookArgs?: HookArgs<T>) => {
   $form: Store<any>;
   state: State<T>;
-  register: (args: RegisterArgs) => any;
+  register: (args: RegisterArgs<T>) => any;
   handleReset: (
     reset: (values: T) => void
   ) => (event: React.FormEvent<HTMLFormElement>) => void;
@@ -131,3 +132,45 @@ export type Form<T> = (hookArgs?: HookArgs<T>) => {
   resetTouched: () => void;
   resetValues: () => void;
 };
+
+type Prev = [
+  never,
+  0,
+  1,
+  2,
+  3,
+  4,
+  5,
+  6,
+  7,
+  8,
+  9,
+  10,
+  11,
+  12,
+  13,
+  14,
+  15,
+  16,
+  17,
+  18,
+  19,
+  20,
+  ...0[]
+];
+
+type Join<K, P> = K extends string | number
+  ? P extends string | number
+    ? `${K}${"" extends P ? "" : "."}${P}`
+    : never
+  : never;
+
+export type Paths<T, D extends number = 10> = [D] extends [never]
+  ? never
+  : T extends object
+  ? {
+      [K in keyof T]-?: K extends string | number
+        ? `${K}` | Join<K, Paths<T[K], Prev[D]>>
+        : never;
+    }[keyof T]
+  : "";


### PR DESCRIPTION
Update `register`, `setFieldValue`, `setFieldError`, and `setFieldTouched` field name type.

```jsx
const useForm = createForm({
  initialValues: {
    email: "",
  },
  mode: "onChange",
});
```

```jsx
 {...register({
      name: "email",
      type: "email",
 })}
```

```jsx
 {...register({
      name: "email2", // gets a typescript error
      type: "email",
 })}
```